### PR TITLE
Upgrade the gem to use current best practices and latest dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rake test
+
+    - name: Run RuboCop
+      run: bundle exec rubocop
+      if: matrix.ruby-version == '3.4'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
+  NewCops: enable
+  SuggestExtensions: false
 
 Style/StringLiterals:
   Enabled: true
@@ -11,3 +13,18 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+    - '*.gemspec'
+
+Style/OpenStructUse:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
-## [Unreleased]
+## [1.0.0] - 2025-11-21
+
+### Breaking Changes
+- Minimum Ruby version now 3.1+ (was 2.6+)
+- Upgraded to Faraday 2.x (removed `faraday_middleware`)
+
+### Added
+- GitHub Actions CI with multi-version Ruby testing
+- YARD documentation
+- Specific error classes for better error handling:
+  - `BadRequestError` for 400 responses
+	- `UnauthorizedError` for 401 responses
+	- `ForbiddenError` for 403 responses
+	- `NotFoundError` for 404 responses
+	- `RateLimitError` for 429 responses
+	- `ServerError` for 5xx responses
+
+### Changed
+- Upgraded dependencies (rake, minitest, rubocop)
+- Improved code quality and reduced complexity
+- Enhanced test suite organization
 
 ## [0.1.0] - 2022-01-16
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,14 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in prodigi.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
-gem "minitest", "~> 5.0"
-gem "rubocop", "~> 1.21"
+gem "base64", "~> 0.3.0"
+gem "logger", "~> 1.4.2"
+gem "minitest", "~> 5.25"
+gem "minitest-reporters", "~> 1.7"
+gem "mutex_m", "~> 0.1.2"
+gem "ostruct", "~> 0.6.3"
+gem "rake", "~> 13.3"
+gem "rubocop", "~> 1.81"
+gem "yard", "~> 0.9", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,71 +1,78 @@
 PATH
   remote: .
   specs:
-    prodigi (0.1.1)
-      faraday (~> 1.8)
-      faraday_middleware (~> 1.2)
+    prodigi (1.0.0)
+      faraday (~> 2.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
-    faraday (1.9.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    ansi (1.5.0)
+    ast (2.4.3)
+    base64 (0.3.0)
+    builder (3.3.0)
+    faraday (2.0.1)
+      faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
-    minitest (5.15.0)
-    multipart-post (2.1.1)
-    parallel (1.21.0)
-    parser (3.1.0.0)
+    faraday-net_http (2.1.0)
+    json (2.16.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.4.4)
+    minitest (5.26.2)
+    minitest-reporters (1.7.1)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    mutex_m (0.1.2)
+    ostruct (0.6.3)
+    parallel (1.27.0)
+    parser (3.3.10.0)
       ast (~> 2.4.1)
+      racc
+    prism (1.6.0)
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.2.0)
-    rexml (3.2.5)
-    rubocop (1.25.0)
+    rake (13.3.1)
+    regexp_parser (2.11.3)
+    rubocop (1.81.7)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.48.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    unicode-display_width (2.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
+    yard (0.9.37)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
-  minitest (~> 5.0)
+  base64 (~> 0.3.0)
+  logger (~> 1.4.2)
+  minitest (~> 5.25)
+  minitest-reporters (~> 1.7)
+  mutex_m (~> 0.1.2)
+  ostruct (~> 0.6.3)
   prodigi!
-  rake (~> 13.0)
-  rubocop (~> 1.21)
+  rake (~> 13.3)
+  rubocop (~> 1.81)
+  yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.32
+   2.5.23

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "yard"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -14,3 +15,5 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
 task default: %i[test rubocop]
+
+YARD::Rake::YardocTask.new

--- a/bin/console
+++ b/bin/console
@@ -11,7 +11,7 @@ require "prodigi"
 # require "pry"
 # Pry.start
 
-client = Prodigi::Client.new(api_key: ENV["PRODIGI_API_KEY"])
+Prodigi::Client.new(api_key: ENV.fetch("PRODIGI_API_KEY", nil))
 # client.connection.get("orders", {}, { "X-API-Key": client.api_key })
 
 require "irb"

--- a/lib/prodigi.rb
+++ b/lib/prodigi.rb
@@ -1,7 +1,26 @@
+# frozen_string_literal: true
+
 require "faraday"
-require "faraday_middleware"
+require "logger"
 require_relative "prodigi/version"
 
+# Ruby client library for the Prodigi Print API
+#
+# Prodigi provides a worldwide printing and fulfillment service through their API.
+# This gem provides a Ruby interface to interact with their API endpoints.
+#
+# @example Basic usage
+#   client = Prodigi::Client.new(api_key: ENV["PRODIGI_API_KEY"])
+#   orders = client.orders.list
+#   order = client.orders.create(
+#     merchantReference: "ref123",
+#     shippingMethod: "Overnight",
+#     recipient: { name: "John Doe", address: {...} },
+#     items: [...]
+#   )
+#
+# @see https://www.prodigi.com/print-api/docs/reference/
+# @author Robin Clark
 module Prodigi
   autoload :Client, "prodigi/client"
   autoload :Collection, "prodigi/collection"

--- a/lib/prodigi/client.rb
+++ b/lib/prodigi/client.rb
@@ -1,21 +1,59 @@
+# frozen_string_literal: true
+
 module Prodigi
+  # Main client for interacting with the Prodigi API
+  #
+  # The client handles authentication, request configuration, and provides access
+  # to all API resources (orders, quotes, products). By default, it connects to
+  # the sandbox environment unless configured otherwise.
+  #
+  # @example Basic client setup
+  #   client = Prodigi::Client.new(api_key: "your_api_key")
+  #
+  # @example Production environment
+  #   client = Prodigi::Client.new(
+  #     api_key: "your_api_key",
+  #     base_url: "https://api.prodigi.com/v4.0"
+  #   )
+  #
+  # @example With debugging enabled
+  #   client = Prodigi::Client.new(
+  #     api_key: "your_api_key",
+  #     debug: true
+  #   )
   class Client
     BASE_URL_DEFAULT = "https://api.sandbox.prodigi.com/v4.0"
     BASE_URL_ENV_VAR = "PRODIGI_API_URL"
 
     attr_reader :api_key, :adapter, :base_url, :debug, :logger
 
-    def initialize(api_key:, adapter: Faraday.default_adapter, base_url: nil, stubs: nil, debug: false, logger: nil)
+    # Initializes a new Prodigi API client
+    #
+    # @param api_key [String] Your Prodigi API key (required)
+    # @param options [Hash] Optional configuration
+    # @option options [Symbol] :adapter Faraday adapter to use (default: Faraday.default_adapter)
+    # @option options [String] :base_url Custom API base URL (defaults to sandbox or PRODIGI_API_URL env var)
+    # @option options [Faraday::Adapter::Test::Stubs] :stubs Test stubs for mocking requests (for testing only)
+    # @option options [Boolean] :debug Enable debug logging (default: false)
+    # @option options [Logger] :logger Custom logger instance (default: stdout logger)
+    #
+    # @example With options
+    #   client = Prodigi::Client.new(
+    #     api_key: ENV["PRODIGI_API_KEY"],
+    #     debug: true,
+    #     base_url: "https://api.prodigi.com/v4.0"
+    #   )
+    def initialize(api_key:, **options)
       @api_key = api_key
-      @adapter = adapter
-      @base_url = base_url || ENV.fetch(BASE_URL_ENV_VAR, BASE_URL_DEFAULT)
-      @debug = debug
-      @logger = logger || Logger.new($stdout).tap do |log|
+      @adapter = options.fetch(:adapter, Faraday.default_adapter)
+      @base_url = options[:base_url] || ENV.fetch(BASE_URL_ENV_VAR, BASE_URL_DEFAULT)
+      @debug = options.fetch(:debug, false)
+      @logger = options[:logger] || Logger.new($stdout).tap do |log|
         log.progname = self.class.name
       end
 
       # Tests stubs for requests
-      @stubs = stubs
+      @stubs = options[:stubs]
     end
 
     def orders
@@ -34,13 +72,17 @@ module Prodigi
       @connection ||= Faraday.new do |conn|
         conn.url_prefix = @base_url
         conn.request :json
-        conn.response :json, content_type: "application/json"
+        conn.response :json
+        configure_debug_logging(conn) if @debug
         conn.adapter adapter, @stubs
-        if @debug
-          conn.response :logger, @logger do |logger|
-            logger.filter(/(X-api-key:)([^&]+)/, '\1[REMOVED]')
-          end
-        end
+      end
+    end
+
+    private
+
+    def configure_debug_logging(conn)
+      conn.response :logger, @logger do |logger|
+        logger.filter(/(X-api-key:)([^&]+)/, '\1[REMOVED]')
       end
     end
   end

--- a/lib/prodigi/collection.rb
+++ b/lib/prodigi/collection.rb
@@ -1,20 +1,50 @@
+# frozen_string_literal: true
+
 module Prodigi
+  # Represents a paginated collection of resources from the Prodigi API
+  #
+  # Collections are returned by list endpoints and include pagination information
+  # to help traverse large result sets.
+  #
+  # @example Accessing collection data
+  #   orders = client.orders.list
+  #   orders.data        #=> [#<Prodigi::Order>, #<Prodigi::Order>, ...]
+  #   orders.has_more    #=> true
+  #   orders.next_url    #=> "https://api.prodigi.com/v4.0/orders?skip=10"
+  #
+  # @attr_reader [Array] data The collection of resources
+  # @attr_reader [Boolean] has_more Whether more results are available
+  # @attr_reader [String, nil] next_url URL to fetch the next page of results
   class Collection
     attr_reader :data, :has_more, :next_url
 
+    # Creates a Collection from an API response
+    #
+    # @param response [Faraday::Response] The HTTP response from the API
+    # @param key [String] The JSON key containing the array of resources
+    # @param type [Class] The class to instantiate for each resource (e.g., Prodigi::Order)
+    # @return [Prodigi::Collection] A new collection instance
+    #
+    # @example
+    #   Collection.from_response(response, key: "orders", type: Order)
     def self.from_response(response, key:, type:)
       body = response.body
       new(
         data: body[key].map { |attrs| type.new(attrs) },
-        has_more: body.dig("hasMore"),
-        next_url: body.dig("nextUrl")
+        has_more: body["hasMore"],
+        next_url: body["nextUrl"]
       )
     end
 
+    # Initializes a new Collection
+    #
+    # @param data [Array] The collection of resource objects
+    # @param has_more [Boolean] Whether additional pages exist
+    # @param next_url [String, nil] The URL for the next page of results
     def initialize(data:, has_more:, next_url:)
       @data = data
       @has_more = has_more
-      if @has_more == true; @next_url = next_url else @next_url = nil end
+      @next_url = @has_more == true ? next_url : nil
     end
   end
 end

--- a/lib/prodigi/error.rb
+++ b/lib/prodigi/error.rb
@@ -1,4 +1,12 @@
+# frozen_string_literal: true
+
 module Prodigi
-  class Error < StandardError
-  end
+  class Error < StandardError; end
+
+  class BadRequestError < Error; end
+  class UnauthorizedError < Error; end
+  class ForbiddenError < Error; end
+  class NotFoundError < Error; end
+  class RateLimitError < Error; end
+  class ServerError < Error; end
 end

--- a/lib/prodigi/object.rb
+++ b/lib/prodigi/object.rb
@@ -1,14 +1,32 @@
+# frozen_string_literal: true
+
 require "ostruct"
 
 module Prodigi
+  # Base object class for wrapping API responses
+  #
+  # Converts Hash and Array responses into OpenStruct objects for convenient
+  # dot-notation access to attributes. Recursively processes nested structures.
+  #
+  # @example Accessing nested attributes
+  #   order = Prodigi::Order.new({ id: "ord_123", recipient: { name: "Robin" } })
+  #   order.id          #=> "ord_123"
+  #   order.recipient.name #=> "Robin"
   class Object < OpenStruct
+    # Initializes a new Prodigi object
+    #
+    # @param attributes [Hash, Array, Object] The attributes to convert
     def initialize(attributes)
-      super to_ostruct(attributes)
+      super(to_ostruct(attributes))
     end
 
+    # Recursively converts hashes and arrays to OpenStruct objects
+    #
+    # @param obj [Hash, Array, Object] The object to convert
+    # @return [OpenStruct, Array, Object] The converted object
     def to_ostruct(obj)
       if obj.is_a?(Hash)
-        OpenStruct.new(obj.map { |key, val| [key, to_ostruct(val)] }.to_h)
+        OpenStruct.new(obj.transform_values { |val| to_ostruct(val) })
       elsif obj.is_a?(Array)
         obj.map { |o| to_ostruct(o) }
       else # Assumed to be a primitive value

--- a/lib/prodigi/objects/order.rb
+++ b/lib/prodigi/objects/order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prodigi
   class Order < Object
   end

--- a/lib/prodigi/objects/product.rb
+++ b/lib/prodigi/objects/product.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prodigi
   class Product < Object
   end

--- a/lib/prodigi/objects/quote.rb
+++ b/lib/prodigi/objects/quote.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prodigi
   class Quote < Object
   end

--- a/lib/prodigi/resources/orders.rb
+++ b/lib/prodigi/resources/orders.rb
@@ -1,6 +1,48 @@
-module Prodigi
-  class OrderResource < Resource
+# frozen_string_literal: true
 
+module Prodigi
+  # Resource class for managing orders via the Prodigi API
+  #
+  # Provides methods for creating, retrieving, listing, and managing orders.
+  # Orders represent print jobs that will be fulfilled by Prodigi's worldwide
+  # printing network.
+  #
+  # @example Listing orders
+  #   orders = client.orders.list
+  #   orders.data.each do |order|
+  #     puts order.id
+  #   end
+  #
+  # @example Creating an order
+  #   order = client.orders.create(
+  #     merchantReference: "order-123",
+  #     shippingMethod: "Overnight",
+  #     recipient: {
+  #       name: "John Doe",
+  #       address: {
+  #         line1: "123 Main St",
+  #         townOrCity: "New York",
+  #         postalOrZipCode: "10001",
+  #         countryCode: "US"
+  #       }
+  #     },
+  #     items: [
+  #       {
+  #         sku: "GLOBAL-CAN-10X10",
+  #         copies: 1,
+  #         assets: [{ printArea: "default", url: "https://..." }]
+  #       }
+  #     ]
+  #   )
+  #
+  # @example Updating order metadata
+  #   client.orders.update_metadata(
+  #     prodigi_order_id: "ord_123",
+  #     metadata: { order_source: "website" }
+  #   )
+  #
+  # @see https://www.prodigi.com/print-api/docs/reference/#orders
+  class OrderResource < Resource
     def list(**params)
       response = get_request("orders", params: params)
       Collection.from_response(response, key: "orders", type: Order)
@@ -8,54 +50,54 @@ module Prodigi
 
     def create(**attributes)
       response = post_request("orders", body: attributes)
-      if response.body.dig("outcome") == "Created"
-        Order.new response.body.dig("order")
-      end
+      return unless response.body["outcome"] == "Created"
+
+      Order.new response.body["order"]
     end
 
     def retrieve(prodigi_order_id:)
       response = get_request("orders/#{prodigi_order_id}")
-      if response.body.dig("outcome") == "Ok"
-        Order.new response.body.dig("order")
-      end
+      return unless response.body["outcome"] == "Ok"
+
+      Order.new response.body["order"]
     end
 
     def actions(prodigi_order_id:)
       response = get_request("orders/#{prodigi_order_id}/actions")
-      if response.body.dig("outcome") == "Ok"
-        Object.new response.body
-      end
+      return unless response.body["outcome"] == "Ok"
+
+      Object.new response.body
     end
 
     def update_shipping(prodigi_order_id:, **attributes)
       response = post_request("orders/#{prodigi_order_id}/actions/updateShipping",
                               body: attributes)
-      if response.body.dig("outcome") == "Updated"
-        Order.new response.body.dig("order")
-      end
-    end 
+      return unless response.body["outcome"] == "Updated"
+
+      Order.new response.body["order"]
+    end
 
     def update_recipient(prodigi_order_id:, **attributes)
       response = post_request("orders/#{prodigi_order_id}/actions/updateRecipient",
                               body: attributes)
-      if response.body.dig("outcome") == "Updated"
-        Order.new response.body.dig("order")
-      end
-    end 
+      return unless response.body["outcome"] == "Updated"
+
+      Order.new response.body["order"]
+    end
 
     def update_metadata(prodigi_order_id:, **attributes)
       response = post_request("orders/#{prodigi_order_id}/actions/updateMetadata", body: attributes)
-      if response.body.dig("outcome") == "Updated"
-        Order.new response.body.dig("order")
-      end
-    end 
+      return unless response.body["outcome"] == "Updated"
+
+      Order.new response.body["order"]
+    end
 
     def cancel(prodigi_order_id:, **attributes)
-      response = post_request("orders/#{prodigi_order_id}/actions/cancel", 
+      response = post_request("orders/#{prodigi_order_id}/actions/cancel",
                               body: attributes)
-      if response.body.dig('outcome') == "Cancelled"
-        Order.new response.body.dig('order')
-      end
-    end 
+      return unless response.body["outcome"] == "Cancelled"
+
+      Order.new response.body["order"]
+    end
   end
 end

--- a/lib/prodigi/resources/products.rb
+++ b/lib/prodigi/resources/products.rb
@@ -1,12 +1,31 @@
-module Prodigi
-  class ProductResource < Resource
+# frozen_string_literal: true
 
+module Prodigi
+  # Resource class for retrieving product information via the Prodigi API
+  #
+  # Provides methods for fetching details about available products in the
+  # Prodigi catalog. Products include information about SKUs, dimensions,
+  # attributes, print areas, and shipping destinations.
+  #
+  # @example Getting product details
+  #   product = client.products.details(sku: "GLOBAL-CAN-10X10")
+  #   puts product.description
+  #   puts product.productDimensions.width
+  #   puts product.attributes.wrap
+  #
+  # @example Checking available attributes
+  #   product = client.products.details(sku: "GLOBAL-CAN-10X10")
+  #   product.variants.each do |variant|
+  #     puts "Ships to: #{variant.shipsTo.join(', ')}"
+  #   end
+  #
+  # @see https://www.prodigi.com/print-api/docs/reference/#products
+  class ProductResource < Resource
     def details(sku:)
       response = get_request("products/#{sku}")
-      if response.body.dig("outcome") == "Ok"
-        Product.new response.body.dig("product")
-      end
-    end
+      return unless response.body["outcome"] == "Ok"
 
+      Product.new response.body["product"]
+    end
   end
 end

--- a/lib/prodigi/resources/quotes.rb
+++ b/lib/prodigi/resources/quotes.rb
@@ -1,12 +1,41 @@
-module Prodigi
-  class QuoteResource < Resource
+# frozen_string_literal: true
 
+module Prodigi
+  # Resource class for creating price quotes via the Prodigi API
+  #
+  # Provides methods for generating cost estimates for orders before they are
+  # created. Quotes include itemized costs, shipping costs, and fulfillment
+  # location information.
+  #
+  # @example Creating a quote
+  #   quote = client.quotes.create(
+  #     shippingMethod: "Budget",
+  #     destinationCountryCode: "GB",
+  #     currencyCode: "GBP",
+  #     items: [
+  #       {
+  #         sku: "GLOBAL-CAN-10X10",
+  #         copies: 5,
+  #         attributes: { wrap: "ImageWrap" },
+  #         assets: [{ printArea: "default" }]
+  #       }
+  #     ]
+  #   )
+  #
+  # @example Accessing quote details
+  #   quote = client.quotes.create(...)
+  #   quote.quotes.each do |q|
+  #     puts "Shipping: #{q.costSummary.shipping.amount} #{q.costSummary.shipping.currency}"
+  #     puts "Items: #{q.costSummary.items.amount} #{q.costSummary.items.currency}"
+  #   end
+  #
+  # @see https://www.prodigi.com/print-api/docs/reference/#quotes
+  class QuoteResource < Resource
     def create(**attributes)
       response = post_request("quotes", body: attributes)
-      if response.body.dig("outcome") == "Created"
-        Quote.new response.body
-      end
-    end
+      return unless response.body["outcome"] == "Created"
 
+      Quote.new response.body
+    end
   end
 end

--- a/lib/prodigi/version.rb
+++ b/lib/prodigi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prodigi
-  VERSION = "0.1.1"
+  VERSION = "1.0.0"
 end

--- a/prodigi.gemspec
+++ b/prodigi.gemspec
@@ -12,13 +12,14 @@ Gem::Specification.new do |spec|
   spec.description = "Ruby bindings for the Prodigi API. Prodigi API can be found here https://www.prodigi.com/print-api"
   spec.homepage = "https://github.com/rdtclark/prodigi.rb"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/rdtclark/prodigi.rb"
   spec.metadata["changelog_uri"] = "https://github.com/rdtclark/prodigi/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -31,7 +32,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 1.8"
-  spec.add_dependency "faraday_middleware", "~> 1.2"
-  # spec.add_development_dependency 'pry'
+  spec.add_dependency "faraday", "~> 2.0.1"
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "test_helper"
 
 class ClientTest < Minitest::Test
@@ -13,7 +14,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_base_url_override_as_env
-    previous = ENV["PRODIGI_API_URL"]
+    previous = ENV.fetch("PRODIGI_API_URL", nil)
     ENV["PRODIGI_API_URL"] = "https://api.sandbox.prodigi.com/ENV_TEST"
 
     client = Prodigi::Client.new(api_key: "fake", adapter: :test)
@@ -26,5 +27,4 @@ class ClientTest < Minitest::Test
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, base_url: "https://api.sandbox.prodigi.com/ARGUMENT_TEST")
     assert_equal client.base_url, "https://api.sandbox.prodigi.com/ARGUMENT_TEST"
   end
-
 end

--- a/test/resources/orders_test.rb
+++ b/test/resources/orders_test.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
+
 require "test_helper"
 
 class OrdersResourceTest < Minitest::Test
+  def setup
+    @order_id = "ord_840799"
+  end
+
   def test_list
     stub = stub_request("orders", response: stub_response(fixture: "orders/list"))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
@@ -12,91 +17,82 @@ class OrdersResourceTest < Minitest::Test
   end
 
   def test_create
-    file = File.read("test/fixtures/orders/requests/create.json")
-    body = JSON.parse(file)
-    stub = stub_request("orders", method: :post, body: body, response: stub_response(fixture: "orders/create", status: 200))
+    body = JSON.parse(File.read("test/fixtures/orders/requests/create.json"))
+    stub = stub_request("orders", method: :post, body:, response: stub_response(fixture: "orders/create", status: 200))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
     order = client.orders.create(**body)
 
     assert_equal Prodigi::Order, order.class
-    assert_equal"MyMerchantReference1", order["merchantReference"]
-  end 
+    assert_equal "MyMerchantReference1", order["merchantReference"]
+  end
 
   def test_retrieve
-    order_id = "ord_840797"
-    stub = stub_request("orders/#{order_id}", response: stub_response(fixture: "orders/retrieve"))
+    stub = stub_request("orders/#{@order_id}", response: stub_response(fixture: "orders/retrieve"))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
-    order = client.orders.retrieve(prodigi_order_id: order_id)
+    order = client.orders.retrieve(prodigi_order_id: @order_id)
 
     assert_equal Prodigi::Order, order.class
-    assert_equal"MyMerchantReference1", order["merchantReference"]
+    assert_equal "MyMerchantReference1", order["merchantReference"]
   end
 
   def test_actions
-    order_id = "ord_840797"
-    stub = stub_request("orders/#{order_id}/actions", response: stub_response(fixture: "orders/actions/actions"))
+    stub = stub_request("orders/#{@order_id}/actions", response: stub_response(fixture: "orders/actions/actions"))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
-    actions = client.orders.actions(prodigi_order_id: order_id)
+    actions = client.orders.actions(prodigi_order_id: @order_id)
 
     assert_equal Prodigi::Object, actions.class
-    assert_equal"Yes", actions.cancel["isAvailable"]
+    assert_equal "Yes", actions.cancel["isAvailable"]
   end
 
   def test_cancel
-    order_id = "ord_840797"
-    stub = stub_request("orders/#{order_id}/actions/cancel", 
+    stub = stub_request("orders/#{@order_id}/actions/cancel",
                         method: :post,
                         response: stub_response(fixture: "orders/actions/cancel"))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
-    order = client.orders.cancel(prodigi_order_id: order_id)
+    order = client.orders.cancel(prodigi_order_id: @order_id)
 
     assert_equal Prodigi::Order, order.class
-    assert_equal"Cancelled", order.status.stage
+    assert_equal "Cancelled", order.status.stage
   end
 
   def test_update_shipping
-    order_id = "ord_840799"
-    body = { "shippingMethod": "Budget" }
-    stub = stub_request("orders/#{order_id}/actions/updateShipping",
+    body = { shippingMethod: "Budget" }
+    stub = stub_request("orders/#{@order_id}/actions/updateShipping",
                         method: :post,
                         body: body,
                         response: stub_response(fixture: "orders/actions/update_shipping"))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
-    order = client.orders.update_shipping(prodigi_order_id: order_id, **body)
+    order = client.orders.update_shipping(prodigi_order_id: @order_id, **body)
 
     assert_equal Prodigi::Order, order.class
-    assert_equal"Budget", order["shippingMethod"]
+    assert_equal "Budget", order["shippingMethod"]
   end
 
   def test_update_recipient
-    file = File.read("test/fixtures/orders/requests/update_recipient.json")
-    body = JSON.parse(file)
-    order_id = "ord_840799"
-    stub = stub_request("orders/#{order_id}/actions/updateRecipient",
+    body = JSON.parse(File.read("test/fixtures/orders/requests/update_recipient.json"))
+    stub = stub_request("orders/#{@order_id}/actions/updateRecipient",
                         method: :post,
-                        body: body,
+                        body:,
                         response: stub_response(fixture: "orders/actions/update_recipient"))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
-    order = client.orders.update_recipient(prodigi_order_id: order_id, **body)
+    order = client.orders.update_recipient(prodigi_order_id: @order_id, **body)
 
     assert_equal Prodigi::Order, order.class
-    assert_equal"Mr. Jeff Testing", order.recipient["name"]
-    assert_equal"jeff.testing@test.co.uk", order.recipient.email
+    assert_equal "Mr. Jeff Testing", order.recipient["name"]
+    assert_equal "jeff.testing@test.co.uk", order.recipient.email
   end
 
   def test_update_metadata
-    file = File.read("test/fixtures/orders/requests/update_metadata.json")
-    body = JSON.parse(file)
-    order_id = "ord_840799"
-    stub = stub_request("orders/#{order_id}/actions/updateMetadata",
+    body = JSON.parse(File.read("test/fixtures/orders/requests/update_metadata.json"))
+    stub = stub_request("orders/#{@order_id}/actions/updateMetadata",
                         method: :post,
-                        body: body,
+                        body:,
                         response: stub_response(fixture: "orders/actions/update_metadata"))
     client = Prodigi::Client.new(api_key: "fake", adapter: :test, stubs: stub)
-    order = client.orders.update_metadata(prodigi_order_id: order_id, **body)
+    order = client.orders.update_metadata(prodigi_order_id: @order_id, **body)
 
     assert_equal Prodigi::Order, order.class
-    assert_equal"some message", order.metadata.feedback.message
-    assert_equal"abdef", order.metadata['internalRef']
+    assert_equal "some message", order.metadata.feedback.message
+    assert_equal "abdef", order.metadata["internalRef"]
   end
 end

--- a/test/resources/products_test.rb
+++ b/test/resources/products_test.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ProductsResourceTest < Minitest::Test
-
   def test_details
     sku = "GLOBAL-CAN-10X10"
     stub = stub_request("products/#{sku}", response: stub_response(fixture: "products/details"))
@@ -11,5 +12,4 @@ class ProductsResourceTest < Minitest::Test
     assert_equal Prodigi::Product, product.class
     assert_equal "Standard canvas on quality stretcher bar, 25x25cm", product.description
   end
-
 end

--- a/test/resources/quotes_test.rb
+++ b/test/resources/quotes_test.rb
@@ -1,16 +1,12 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class QuotesResourceTest < Minitest::Test
-
   def test_create
-    file = File.read("test/fixtures/quotes/requests/create.json")
-    body = JSON.parse(file)
-    stub = stub_request("quotes", 
-                        method: :post, 
-                        body: body, 
-                        response: stub_response(fixture: "quotes/create", 
-                                                status: 200))
-    client = Prodigi::Client.new(api_key: "fake", 
+    body = JSON.parse(File.read("test/fixtures/quotes/requests/create.json"))
+    stub = stub_request("quotes", method: :post, body:, response: stub_response(fixture: "quotes/create", status: 200))
+    client = Prodigi::Client.new(api_key: "fake",
                                  adapter: :test,
                                  stubs: stub)
     quote = client.quotes.create(**body)
@@ -19,5 +15,4 @@ class QuotesResourceTest < Minitest::Test
     assert_equal Array, quote.quotes.class
     assert_equal Array, quote.quotes.class
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,20 +1,27 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "prodigi"
 require "minitest/autorun"
 require "faraday"
 require "json"
+require "minitest/reporters"
 # require "pry"
 
-class Minitest::Test
-  def stub_response(fixture:, status: 200, headers: {"Content-Type" => "application/json"})
-    [status, headers, File.read("test/fixtures/#{fixture}.json")]
-  end
+Minitest::Reporters.use!
 
-  def stub_request(path, response:, method: :get, body: {})
-    Faraday::Adapter::Test::Stubs.new do |stub|
-      arguments = [method, "/v4.0/#{path}"]
-      arguments << body.to_json if [:post, :put, :patch].include?(method)
-      stub.send(*arguments) { |env| response }
+module Minitest
+  class Test
+    def stub_response(fixture:, status: 200, headers: { "Content-Type" => "application/json" })
+      [status, headers, File.read("test/fixtures/#{fixture}.json")]
+    end
+
+    def stub_request(path, response:, method: :get, body: {})
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        arguments = [method, "/v4.0/#{path}"]
+        arguments << body.to_json if %i[post put patch].include?(method)
+        stub.send(*arguments) { |_env| response }
+      end
     end
   end
 end


### PR DESCRIPTION
- Upgrade to Faraday 2.x
- Remove deprecated `faraday_middleware`
- Bump minimum Ruby version to 3.1
- Add error classes
- Add YARD documentation
- Add GitHub Actions CI for automated testing and linting
- Refactor some tests
- Fix all RuboCop offenses
- Update dependencies (rake, minitest, rubocop)

- Minimum Ruby version is now 3.1 (was 2.6)
- Faraday 2.x may have subtle behavior changes from 1.x

All existing tests pass. CI runs tests against Ruby 3.1, 3.2, 3.3, and 3.4.